### PR TITLE
Suggestions for #6701

### DIFF
--- a/src/UI/Implementation/Component/Input/Container/ViewControl/ViewControl.php
+++ b/src/UI/Implementation/Component/Input/Container/ViewControl/ViewControl.php
@@ -81,7 +81,7 @@ abstract class ViewControl extends Container implements I\ViewControl
         return $this->request;
     }
 
-    public function withStoredValues(Input\ArrayInputData $input): self
+    public function withStoredInput(Input\ArrayInputData $input): self
     {
         $clone = clone $this;
         $clone->stored_input = $input;

--- a/src/UI/Implementation/Component/Table/Factory.php
+++ b/src/UI/Implementation/Component/Table/Factory.php
@@ -40,7 +40,7 @@ class Factory implements T\Factory
         protected T\Column\Factory $column_factory,
         protected T\Action\Factory $action_factory,
         protected DataRowBuilder $data_row_builder,
-        protected \ArrayAccess $session,
+        protected \ArrayAccess $storage,
     ) {
     }
 
@@ -69,7 +69,7 @@ class Factory implements T\Factory
             $title,
             $columns,
             $data_retrieval,
-            $this->session
+            $this->storage
         );
     }
 

--- a/tests/UI/Component/Table/DataViewControlsTest.php
+++ b/tests/UI/Component/Table/DataViewControlsTest.php
@@ -169,7 +169,7 @@ class DataViewControlsTest extends TableTestBase
         return $request;
     }
 
-    public function testDataTableViewControlsSessionStorage(): void
+    public function testDataTableViewControlStorage(): void
     {
         $factory = $this->getTableFactory();
         $columns = [

--- a/tests/UI/Component/Table/TableTestBase.php
+++ b/tests/UI/Component/Table/TableTestBase.php
@@ -81,30 +81,21 @@ abstract class TableTestBase extends ILIAS_UI_TestBase
             new C\Table\Column\Factory(),
             new C\Table\Action\Factory(),
             new C\Table\DataRowBuilder(),
-            $this->getSessionStorage()
+            $this->getMockStorage()
         );
     }
 
-    protected function getSessionStorage(): ArrayAccess
+    protected function getMockStorage(): ArrayAccess
     {
         return new class () implements ArrayAccess {
-            protected ?string $id = null;
             protected array $data = [];
-
-            public function get(string $id)
-            {
-                $this->id = $id;
-                $this->data = $_SESSION[$id] ?? [];
-                return $this;
-            }
-
             public function offsetExists(mixed $offset): bool
             {
-                return array_key_exists($offset, $this->data);
+                return isset($this->data[$offset]);
             }
             public function offsetGet(mixed $offset): mixed
             {
-                if(! $this->offsetExists($offset)) {
+                if(!$this->offsetExists($offset)) {
                     return null;
                 }
                 return $this->data[$offset];
@@ -112,12 +103,10 @@ abstract class TableTestBase extends ILIAS_UI_TestBase
             public function offsetSet(mixed $offset, mixed $value): void
             {
                 $this->data[$offset] = $value;
-                $_SESSION[$this->id] = $this->data;
             }
             public function offsetUnset(mixed $offset): void
             {
                 unset($this->data[$offset]);
-                $_SESSION[$this->id] = $this->data;
             }
         };
     }


### PR DESCRIPTION
Hi @nhaagen 

I was reviewing your PR #6701 when I noticed that the storage handling is more complicated than it needs to.
I thought it would be easier for the both of us, if I implement the changes instead of writing them down in a review. Concretely:

- The anonymous implementation of `ArrayAccess` now forwards most of the logic to the session directly.
- The anonymous class does not implement a public method anymore, since this is not exposed by some kind of interface.
- The manipulations are now performed more or less directly on the session, using `ArrayAccess` passes storages by reference.
- I removed `Data::getInputDataFromSession()` because we don't need to filter values, `withInput()` will ultimately do so.
- I streamlined the term "storage" a bit, since IMO we should keep this as abstract as possible, because the session is only one possible sort of storage. 1 could also use a cookie.
- The unit-tests don't use the `$_SESSION` variable anymore, this could cause flaky tests.
- The `DataTest` needed some adapting to the changes in the table.

Feel free to merge these changes into your PR, otherwise you may close this and I will try to formulate them in a proper review.

Kind regards,
@thibsy